### PR TITLE
Automate deployment to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,11 @@ script:
      git push -f https://jenkins-nedprod:$JENKINS_NEDPROD_PASSWORD@github.com/ned14/boost.outcome gh-pages;
      cd ../..;
    fi
+
+deploy:
+  provider: pypi
+  user: $PYPI_USERNAME
+  password: $PYPI_PASSWORD
+  distributions: "sdist bdist_wheel"
+  on:
+    tags: true


### PR DESCRIPTION
This PR build on #2 to automate deployment of new releases to PyPI

Any time a new version tag is created, and travis tests pass, the package will be released to PyPI automatically.

This makes releasing a new version easier and less error-prone as all that's required is making a new git tag or a new release on the github releases page and a few minutes later it'll be updated on PyPI without having to remember the procedure.

Note: This modification to the travis hasn't been tested personally as it's dependent on your PyPI credentials being added to the travis repository secure variables as PYPI_USERNAME and PYPI_PASSWORD
https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings

It also assumes that secure environment variables work in the deployment stage. 
I typically use gitlab and it's built in ci for doing this rather than travis so not as familiar with the config and restrictions.

If this doesn't work the documented alternative is the secure variables generated with the travis command line client (which I haven't used either):
https://docs.travis-ci.com/user/deployment/pypi/
https://stackoverflow.com/a/33783088/3093392